### PR TITLE
Updates for 2022

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,17 +5,13 @@
 *.dll
 *.so
 *.dylib
+.editorconfig
 
 # Test binary, build with `go test -c`
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-
-# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
-.glide/
-glide.lock
-vendor/
 
 .idea/
 bin/

--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,15 @@ fmt: ## run go fmt
 
 build-windows: files ## build the go packages
 	@echo "Running $@"
-	@CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -i -ldflags "-X main.Version=${VERSION}" -o bin/windows/${BINARY}.exe .
+	@CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-X main.Version=${VERSION}" -o bin/windows/${BINARY}.exe .
 
 build-darwin: files ## build the go packages
 	@echo "Running $@"
-	@CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -i -ldflags "-X main.Version=${VERSION}" -o bin/darwin/${BINARY} .
+	@CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.Version=${VERSION}" -o bin/darwin/${BINARY} .
 
 build-linux: files ## build the go packages for Linux (useful to copy the binary into docker)
 	@echo "Running $@"
-	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -i -ldflags "-X main.Version=${VERSION}" -o bin/linux/${BINARY} .
+	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=${VERSION}" -o bin/linux/${BINARY} .
 
 test: ## run test
 	@echo "Running $@"

--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ This will download today's challenge with python boilerplate
 
 ## Development
 
-Glide is needed for dep management
-
-```glide update```
-
 To produce the binaries needed run
 
 ```

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,3 +1,0 @@
-package: github.com/AnthonyNixon/advent-of-code-boilerplate
-import:
-  - package: github.com/alecthomas/kingpin

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/anthonynixon/advent-of-code-boilerplate
+
+go 1.19
+
+require github.com/alecthomas/kingpin v2.2.6+incompatible
+
+require (
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/alecthomas/kingpin v2.2.6+incompatible h1:5svnBTFgJjZvGKyYBtMB0+m5wvrbUHiqye8wRJMlnYI=
+github.com/alecthomas/kingpin v2.2.6+incompatible/go.mod h1:59OFYbFVLKQKq+mqrL6Rw5bR0c3ACQaawgXx0QYndlE=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
+github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
- Updates to use Go Mod instead of Glide
- Updates readme to remove glide references
- Update build commands in makefile to remove deprecated `-i` flag

