### PR TITLE
feat(timezone): automatically adjust timezone to eastern.

### DIFF
--- a/aoc-boilerplate/utils/time.go
+++ b/aoc-boilerplate/utils/time.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"fmt"
+	"time"
+)
+
+func GetCurrentDay() (day string) {
+	loc, err := time.LoadLocation("America/New_York")
+	Check(err)
+
+	now := time.Now().In(loc)
+	day = fmt.Sprintf("%d", now.Day())
+	return
+}
+
+func GetCurrentYear() (year string) {
+
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"os"
 
+	"github.com/anthonynixon/advent-of-code-boilerplate/aoc-boilerplate/utils"
+
 	new_day "github.com/anthonynixon/advent-of-code-boilerplate/aoc-boilerplate/new-day"
 	"github.com/anthonynixon/advent-of-code-boilerplate/aoc-boilerplate/templating"
 	"github.com/anthonynixon/advent-of-code-boilerplate/aoc-boilerplate/token"
@@ -24,10 +26,10 @@ var (
 	languages      = app.Command("languages", "Shows all currently configured languages")
 
 	newDay       = app.Command("get", "Bootstrap a new day for aoc")
-	day          = newDay.Arg("dayNum", "The day to pull inputs for").Default(fmt.Sprintf("%d", time.Now().Day())).Int()
+	day          = newDay.Arg("day", "The day to pull inputs for").Default(utils.GetCurrentDay()).Int()
+	year         = newDay.Flag("year", "The year to be used.").Default(fmt.Sprintf("%d", time.Now().Year())).Int()
 	sessionToken = newDay.Flag("session", "Your session token. Visit https://github.com/AnthonyNixon/advent-of-code-boilerplate/blob/main/docs/setup/session.md for instructions.").Envar("AOC_SESSION").Required().String()
 	lang         = newDay.Flag("lang", "Which language the boilerplate code should be generated in.").Default("go").Envar("AOC_LANG").String()
-	year         = newDay.Flag("year", "The year to be used.").Default(fmt.Sprintf("%d", time.Now().Year())).Int()
 
 	update        = app.Command("update", "Update AOC binary")
 	updateVersion = update.Arg("version", "an optional specified version to updater to").Default("latest").String()

--- a/templates/go_template.go
+++ b/templates/go_template.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"flag"
+	"fmt"
 	"os"
 )
 
@@ -18,8 +19,15 @@ func main() {
 	}
 	input_file, err := readLines(filename)
 	check(err)
-	// Your Code goes below!
 
+	// Your Code goes below!
+	part1, part2 := 0, 0
+	for _, line := range input_file {
+
+	}
+
+	fmt.Printf("Part1: %v\n", part1)
+	fmt.Printf("Part2: %v\n", part2)
 }
 
 func check(e error) {


### PR DESCRIPTION
This will make it so running `./aoc get` after the newest puzzle is released will get the newest puzzle's input, regardless of the user's timezone.


Also updates the golang template to include solution printing and iterating of the input file.